### PR TITLE
add environment variables due to ERROR when convert PTH model to HuggingFace model

### DIFF
--- a/xtuner/README.md
+++ b/xtuner/README.md
@@ -272,7 +272,7 @@ NPROC_PER_NODE=${GPU_NUM} xtuner train ./internlm_chat_7b_qlora_oasst1_e3_copy.p
 ```bash
 mkdir hf
 export MKL_SERVICE_FORCE_INTEL=1
-
+export MKL_THREADING_LAYER=GNU
 xtuner convert pth_to_hf ./internlm_chat_7b_qlora_oasst1_e3_copy.py ./work_dirs/internlm_chat_7b_qlora_oasst1_e3_copy/epoch_1.pth ./hf
 ```
 此时，路径中应该长这样：


### PR DESCRIPTION
没有导入环境变量MKL_THREADING_LAYER=GNU前，如果按照教程执行，会有关于mkl-service相关的报错，如图
![f603feb8e44703b5f2f554ebe1bb2e6b](https://github.com/InternLM/tutorial/assets/124784234/b2f76e1a-cde4-4f53-a8cf-e89eac305eff)

导入环境变量后MKL_THREADING_LAYER=GNU后，同样按照教程执行，报错消失了，如图
![4a522e5e2196f7490a2b52ada4dcd3f9](https://github.com/InternLM/tutorial/assets/124784234/8a5c116f-3cc2-4714-a2bd-23e44e6f854a)

参考信息来源：https://www.zywvvd.com/notes/study/deep-learning/bug-fix/mkl-service-err-message/mkl-service-err-message/