### PR TITLE
fix:安装依赖时报错， No matching distribution found for BCEmbedding==0.15

### DIFF
--- a/docs/L2/Huixiangdou/readme.md
+++ b/docs/L2/Huixiangdou/readme.md
@@ -253,7 +253,7 @@ conda activate huixiangdou
 apt update
 apt install python-dev libxml2-dev libxslt1-dev antiword unrtf poppler-utils pstotext tesseract-ocr flac ffmpeg lame libmad0 libsox-fmt-mp3 sox libjpeg-dev swig libpulse-dev
 # python requirements
-pip install BCEmbedding==0.15 cmake==3.30.2 lit==18.1.8 sentencepiece==0.2.0 protobuf==5.27.3 accelerate==0.33.0
+pip install BCEmbedding==0.1.5 cmake==3.30.2 lit==18.1.8 sentencepiece==0.2.0 protobuf==5.27.3 accelerate==0.33.0
 pip install -r requirements.txt
 # python3.8 安装 faiss-gpu 而不是 faiss
 ```


### PR DESCRIPTION
fix
安装依赖时错误，错误信息如下：
ERROR: Could not find a version that satisfies the requirement BCEmbedding==0.15 (from versions: 0.0.4, 0.0.5, 0.0.6, 0.0.7, 0.0.8, 0.1.1, 0.1.2, 0.1.3, 0.1.4, 0.1.5)
ERROR: No matching distribution found for BCEmbedding==0.15
