### PR TITLE
Update readme_api.md

### DIFF
--- a/docs/L1/LlamaIndex/readme_api.md
+++ b/docs/L1/LlamaIndex/readme_api.md
@@ -159,7 +159,7 @@ touch test_internlm.py
 ```python
 from openai import OpenAI
 
-base_url = "https://internlm-chat.intern-ai.org.cn/puyu/api/v1/",
+base_url = "https://internlm-chat.intern-ai.org.cn/puyu/api/v1/"
 api_key = "sk-请填写准确的 token！"
 model="internlm2.5-latest"
 


### PR DESCRIPTION
base_url = "https://internlm-chat.intern-ai.org.cn/puyu/api/v1/"后有多余的逗号，会导致输出base_url类型错误(tuple)